### PR TITLE
update getSessionKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,15 +26,15 @@ module.exports = {
         let cypher = 'aes-' + keyLength * 8 + '-cbc';
 
         //Get session object
-        laravelSession = new Buffer(laravelSession, 'base64');
+        laravelSession = Buffer.from(laravelSession, 'base64');
         laravelSession = laravelSession.toString();
         laravelSession = JSON.parse(laravelSession);
 
         //Create key buffer
-        laravelKey = new Buffer(laravelKey, 'base64');
+        laravelKey = Buffer.from(laravelKey, 'base64');
 
         //crypto required iv in binary or buffer
-        laravelSession.iv = new Buffer(laravelSession.iv, 'base64');
+        laravelSession.iv = Buffer.from(laravelSession.iv, 'base64');
 
         //create decoder
         let decoder = crypto.createDecipheriv(cypher, laravelKey, laravelSession.iv);
@@ -42,8 +42,8 @@ module.exports = {
         //add data to decoder and return decoded
         let decoded = decoder.update(laravelSession.value, 'base64');
 
-        //unserialize
-        return unserialize(decoded);
+        //toString()
+        return decoded.toString() + decoder.final().toString();
     },
     getSessionFromFile: function (laravelSessionKey, filePath) {
         return new Promise(function (resolve, reject) {


### PR DESCRIPTION
Hi this PR is about updating `getSessionKey`

From npm log's i saw that creating a `new Buffer` is deprecating, instead we should use, Buffer.alloc(), Buffer.from() functions. I updated those and also,

when we use unserialize() function it was always giving us a part of sessionID, i updated that to

line -> 25
`decoded.toString() + decoder.final().toString()`
now give's you all ID,

Please give it a try :)